### PR TITLE
fix: prevent spurious newlines when editing headers

### DIFF
--- a/src/align-icons-item.ts
+++ b/src/align-icons-item.ts
@@ -12,19 +12,22 @@ export default class AlignIconsItem implements PluginValue {
 		this.mdText = new MDText(update.state.doc.toString())
 		const imageContainerDivs = update.view.dom.getElementsByClassName("image-embed")
 		
-		Array.from(imageContainerDivs).forEach((imageContainerDiv: any) => {
-			const img = imageContainerDiv.children[0]
-			
-			const classes = Array.from(imageContainerDiv.children).map((x: any) => x.className)
-			if (imageContainerDiv.children[0].tagName === "IMG" && !(classes.includes(this.alignIconsClassName))) {
-				this.addAlignIcons(img)
-			}
+                Array.from(imageContainerDivs).forEach((imageContainerDiv: any) => {
+                        const img = imageContainerDiv.children[0]
 
-			if (!imageContainerDiv.className.includes("images-tools-text-align-")) {
-				const textAlignClassName = "images-tools-text-align-" + this.mdText.getImageText(img.parentNode.getAttribute("src")).align
-				imageContainerDiv.classList.add(textAlignClassName)
-			}
-		})
+                        const classes = Array.from(imageContainerDiv.children).map((x: any) => x.className)
+                        if (imageContainerDiv.children[0].tagName === "IMG" && !(classes.includes(this.alignIconsClassName))) {
+                                this.addAlignIcons(img)
+                        }
+
+                        if (!imageContainerDiv.className.includes("images-tools-text-align-")) {
+                                const imageText = this.mdText.getImageText(img.parentNode.getAttribute("src"))
+                                if (imageText && imageText.align) {
+                                        const textAlignClassName = "images-tools-text-align-" + imageText.align
+                                        imageContainerDiv.classList.add(textAlignClassName)
+                                }
+                        }
+                })
 	}
 
 	addAlignIcons(img: any) {
@@ -72,15 +75,19 @@ export default class AlignIconsItem implements PluginValue {
 		return icon
 	}
 
-	setNewAlignForImage(img: any, newAlign: string) {
-		const imgName = img.parentNode.getAttribute("src")
-		let imageText = this.mdText.getImageText(imgName)
-		let [indexStart, indexEnd] = this.mdText.getImageIndexes(imgName)
-		imageText.setAlign(newAlign)
+        setNewAlignForImage(img: any, newAlign: string) {
+                const imgName = img.parentNode.getAttribute("src")
+                const imageText = this.mdText.getImageText(imgName)
+                const [indexStart, indexEnd] = this.mdText.getImageIndexes(imgName)
+                if (!imageText || indexStart === -1 || indexEnd === -1) {
+                        return
+                }
 
-		const changes = this.viewUpdate.state.update({
-			changes: {from: indexStart, to: indexEnd, insert: imageText.getImageText()}
-		})
-		this.viewUpdate.view.dispatch(changes)
-	}
+                imageText.setAlign(newAlign)
+
+                const changes = this.viewUpdate.state.update({
+                        changes: {from: indexStart, to: indexEnd, insert: imageText.getImageText()}
+                })
+                this.viewUpdate.view.dispatch(changes)
+        }
 }

--- a/src/image-text.ts
+++ b/src/image-text.ts
@@ -5,55 +5,67 @@ export default class ImageText {
 	type: "local" | "url"
 	name: string | undefined
 
-	constructor(text: string) {
-		if (text.startsWith("![[")) {
-			this.parseLocalImage(text)
-		} else {
-			this.parseUrlImage(text)
-		}
-	}
+        constructor(text: string) {
+                if (text.startsWith("![[")) {
+                        this.parseLocalImage(text)
+                } else {
+                        this.parseUrlImage(text)
+                }
+        }
 
-	parseLocalImage(text: string) {
-		this.type = "local"
-		const params = text.slice(3, text.length-2).split("|")
-		this.img = params[0]
+        parseLocalImage(text: string) {
+                this.type = "local"
 
-		if (params.length == 3) {
-			this.align = params[1]
-			this.width = params[2]
-			return
-		}
+                const match = text.match(/!\[\[(.*?)\]\]/)
+                if (!match) {
+                        return
+                }
 
-		if (params.length == 2) {
-			if (params[1] == "left" || params[1] == "center" || params[1] == "right") {
-				this.align = params[1]
-			} else {
-				this.width = params[1]
-			}
-		}
-	}
+                const params = match[1].split("|")
+                this.img = params[0]
 
-	parseUrlImage(text: string) {
-		this.type = "url"
-		const prefix = text.split("]")[0].split("[")[1]
-		const params = prefix.split("|")
-		this.name = params[0]
+                if (params.length == 3) {
+                        this.align = params[1]
+                        this.width = params[2]
+                        return
+                }
 
-		if (params.length == 3) {
-			this.align = params[1]
-			this.width = params[2]
-		}
+                if (params.length == 2) {
+                        if (params[1] == "left" || params[1] == "center" || params[1] == "right") {
+                                this.align = params[1]
+                        } else {
+                                this.width = params[1]
+                        }
+                }
+        }
 
-		if (params.length == 2) {
-			if (params[1] == "left" || params[1] == "center" || params[1] == "right") {
-				this.align = params[1]
-			} else {
-				this.width = params[1]
-			}
-		}
+        parseUrlImage(text: string) {
+                this.type = "url"
 
-		this.img = text.split("(")[1].split(")")[0]
-	}
+                const match = text.match(/!\[(.*?)\]\((.*?)\)/)
+                if (!match) {
+                        return
+                }
+
+                const prefix = match[1]
+                const params = prefix.split("|")
+                this.name = params[0]
+
+                if (params.length == 3) {
+                        this.align = params[1]
+                        this.width = params[2]
+                }
+
+                if (params.length == 2) {
+                        if (params[1] == "left" || params[1] == "center" || params[1] == "right") {
+                                this.align = params[1]
+                        } else {
+                                this.width = params[1]
+                        }
+                }
+
+                this.img = match[2]
+        }
 
 	getImageText() {
 		return this.type === "local" ? this.getLocalImageText() : this.getUrlImageText()
@@ -78,9 +90,8 @@ export default class ImageText {
 		if (this.width !== undefined) {
 			prefix += "|" + this.width
 		}
-		console.log(this.img)
-		return `![${prefix}](${this.img})`
-	}
+                return `![${prefix}](${this.img})`
+        }
 
 	setWidth(newWidth: string) {
 		this.width = newWidth

--- a/src/md-text.ts
+++ b/src/md-text.ts
@@ -1,65 +1,72 @@
 import ImageText from "./image-text";
 
 export default class MDText {
-	text: string
+        text: string
 
-	constructor(text: string) {
-		this.text = text
-	}
+        constructor(text: string) {
+                this.text = text
+        }
 
-	getImageIndexes(imgText: string) {
-		console.log("getImageIndexes", imgText)
-		if (this.isLocalImage(imgText)) {
-			console.log("isLocalImage")
-			return this.getLocalImageIndexes(imgText)
-		}
+        getImageIndexes(imgText: string | null): [number, number] {
+                if (!imgText) {
+                        return [-1, -1]
+                }
 
-		if (this.isUrlImage(imgText)) {
-			console.log("isUrlImage")
-			return this.getUrlImageIndexes(imgText)
-		}
+                if (this.isLocalImage(imgText)) {
+                        return this.getLocalImageIndexes(imgText)
+                }
 
-		console.log("[0, 0]")
-		return [0, 0]
-	}
+                if (this.isUrlImage(imgText)) {
+                        return this.getUrlImageIndexes(imgText)
+                }
 
-	isLocalImage(imgText: string) {
-		return this.text.indexOf(`![[${imgText}`) !== -1
-	}
+                return [-1, -1]
+        }
 
-	isUrlImage(imgText: string) {
-		const regex = new RegExp(`!\\[.+\\]\\(${imgText}\\)`)
-		const match = this.text.match(regex)
-		return !!match
-	}
+        isLocalImage(imgText: string | null) {
+                if (!imgText) {
+                        return false
+                }
+                return this.text.indexOf(`![[${imgText}`) !== -1
+        }
 
-	getLocalImageIndexes(imgText: string) {
-		const indexStart = this.text.indexOf(`![[${imgText}`)
-		let indexEnd = indexStart
-		for (let i = indexStart + 1; i < this.text.length; i++) {
-			if (this.text[i] === "]" && this.text[i+1] === "]") {
-				indexEnd = i + 2
-				break
-			}
-		}
-		return [indexStart, indexEnd]
-	}	
+        isUrlImage(imgText: string | null) {
+                if (!imgText) {
+                        return false
+                }
+                const regex = new RegExp(`!\\[.+\\]\\(${imgText}\\)`)
+                const match = this.text.match(regex)
+                return !!match
+        }
 
-	getUrlImageIndexes(imgText: string) {
-		const regex = new RegExp(`!\\[.+\\]\\(${imgText}\\)`)
-		const match = this.text.match(regex)
-		
-		if (match && match.index !== undefined) {
-			return [match.index, match.index + match[0].length]
-		}
+        getLocalImageIndexes(imgText: string): [number, number] {
+                const indexStart = this.text.indexOf(`![[${imgText}`)
+                let indexEnd = indexStart
+                for (let i = indexStart + 1; i < this.text.length; i++) {
+                        if (this.text[i] === "]" && this.text[i+1] === "]") {
+                                indexEnd = i + 2
+                                break
+                        }
+                }
+                return [indexStart, indexEnd]
+        }
 
-		return [0, 0]
-	}
+        getUrlImageIndexes(imgText: string): [number, number] {
+                const regex = new RegExp(`!\\[.+\\]\\(${imgText}\\)`)
+                const match = this.text.match(regex)
 
-	getImageText(imgText: string) {
-		console.log("getImageText", imgText)
-		const [indexStart, indexEnd] = this.getImageIndexes(imgText)
-		console.log("getImageText", [indexStart, indexEnd])
-		return new ImageText(this.text.slice(indexStart, indexEnd))
-	}
+                if (match && match.index !== undefined) {
+                        return [match.index, match.index + match[0].length]
+                }
+
+                return [-1, -1]
+        }
+
+        getImageText(imgText: string | null) {
+                const [indexStart, indexEnd] = this.getImageIndexes(imgText)
+                if (indexStart === -1 || indexEnd === -1) {
+                        return undefined
+                }
+                return new ImageText(this.text.slice(indexStart, indexEnd))
+        }
 }

--- a/src/resize-icons-item.ts
+++ b/src/resize-icons-item.ts
@@ -12,19 +12,25 @@ export default class ResizeIconsItem implements PluginValue {
 		this.mdText = new MDText(update.state.doc.toString())
 		const images = update.view.dom.getElementsByClassName("image-embed")
 
-		Array.from(images).forEach(img => {
-			const classes = Array.from(img.children).map(x => x.className)
-			if (img.children[0].tagName === "IMG" && !(classes.includes(this.rightResizeIconClassName))) {
-				this.addRightResizeIcon(img.children[0])
-			}
-		})
+                Array.from(images).forEach(img => {
+                        const classes = Array.from(img.children).map(x => x.className)
+                        if (img.children[0].tagName === "IMG" && !(classes.includes(this.rightResizeIconClassName))) {
+                                const imgName = img.getAttribute("src")
+                                if (this.mdText.getImageText(imgName)) {
+                                        this.addRightResizeIcon(img.children[0])
+                                }
+                        }
+                })
 
-		Array.from(images).forEach(img => {
-			const classes = Array.from(img.children).map(x => x.className)
-			if (img.children[0].tagName === "IMG" && !(classes.includes(this.leftResizeIconClassName))) {
-				this.addLeftResizeIcon(img.children[0])
-			}
-		})
+                Array.from(images).forEach(img => {
+                        const classes = Array.from(img.children).map(x => x.className)
+                        if (img.children[0].tagName === "IMG" && !(classes.includes(this.leftResizeIconClassName))) {
+                                const imgName = img.getAttribute("src")
+                                if (this.mdText.getImageText(imgName)) {
+                                        this.addLeftResizeIcon(img.children[0])
+                                }
+                        }
+                })
 	}
 
 	addRightResizeIcon(item: any) {
@@ -87,15 +93,18 @@ export default class ResizeIconsItem implements PluginValue {
 		item.parentNode?.append(icon)
 	}
 
-	setNewWidthForImage(img: any, newWidth: number) {
-		const imgName = img.parentNode.getAttribute("src")
-		let imageText = this.mdText.getImageText(imgName)
-		let [indexStart, indexEnd] = this.mdText.getImageIndexes(imgName)
-		imageText.setWidth(newWidth.toString())
+        setNewWidthForImage(img: any, newWidth: number) {
+                const imgName = img.parentNode.getAttribute("src")
+                const imageText = this.mdText.getImageText(imgName)
+                const [indexStart, indexEnd] = this.mdText.getImageIndexes(imgName)
+                if (!imageText || indexStart === -1 || indexEnd === -1) {
+                        return
+                }
+                imageText.setWidth(newWidth.toString())
 
-		const changes = this.viewUpdate.state.update({
-			changes: {from: indexStart, to: indexEnd, insert: imageText.getImageText()}
-		})
-		this.viewUpdate.view.dispatch(changes)
-	}
+                const changes = this.viewUpdate.state.update({
+                        changes: {from: indexStart, to: indexEnd, insert: imageText.getImageText()}
+                })
+                this.viewUpdate.view.dispatch(changes)
+        }
 }


### PR DESCRIPTION
## Summary
- guard image text parsing to tolerate invalid strings
- skip alignment and resize updates when image text is missing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd761f920c83329d08574b3aeb4776